### PR TITLE
处理jsonpath断言，期望结果本身包含英文逗号的情况，处理策略：本身包含英文逗号，在逗号前加&符号，由于后端处理策略是split()方…

### DIFF
--- a/src/main/java/luckyclient/caserun/exinterface/TestCaseExecution.java
+++ b/src/main/java/luckyclient/caserun/exinterface/TestCaseExecution.java
@@ -12,6 +12,7 @@ import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
+import org.apache.commons.compress.utils.Lists;
 import org.openqa.selenium.WebDriver;
 
 import io.appium.java_client.android.AndroidDriver;
@@ -293,7 +294,13 @@ public class TestCaseExecution {
                         expectedresults = expectedresults.substring(JSONPATH_SIGN.length());
                         String jsonpath = expectedresults.split("=")[0];
                         String exceptResult = expectedresults.split("=")[1];
-                        List<String> exceptResults = Arrays.asList(exceptResult.split(","));
+                        List<String> exceptResultList = Arrays.asList(exceptResult.split("(?<!&),"));
+                        List<String> exceptResults = Lists.newArrayList();
+                        // 处理期望值里本身包含英文逗号的情况
+                        for (String s : exceptResultList) {
+                            s = s.replace("&,",",");
+                            exceptResults.add(s);
+                        }
                         Configuration conf = Configuration.defaultConfiguration();
                         JSONArray datasArray = JSON.parseArray(JSON.toJSONString(JsonPath.using(conf).parse(testnote).read(jsonpath)));
                         List<String> result = JSONObject.parseArray(datasArray.toJSONString(), String.class);
@@ -537,7 +544,13 @@ public class TestCaseExecution {
                     expectedresults = expectedresults.substring(JSONPATH_SIGN.length());
                     String jsonpath = expectedresults.split("=")[0];
                     String exceptResult = expectedresults.split("=")[1];
-                    List<String> exceptResults = Arrays.asList(exceptResult.split(","));
+                    List<String> exceptResultList = Arrays.asList(exceptResult.split("(?<!&),"));
+                    List<String> exceptResults = Lists.newArrayList();
+                    // 处理期望值里本身包含英文逗号的情况
+                    for (String s : exceptResultList) {
+                        s = s.replace("&,",",");
+                        exceptResults.add(s);
+                    }
                     Configuration conf = Configuration.defaultConfiguration();
                     JSONArray datasArray = JSON.parseArray(JSON.toJSONString(JsonPath.using(conf).parse(testnote).read(jsonpath)));
                     List<String> result = JSONObject.parseArray(datasArray.toJSONString(), String.class);

--- a/src/main/java/luckyclient/caserun/exinterface/ThreadForExecuteCase.java
+++ b/src/main/java/luckyclient/caserun/exinterface/ThreadForExecuteCase.java
@@ -21,6 +21,7 @@ import luckyclient.publicclass.LogUtil;
 import luckyclient.serverapi.entity.ProjectCase;
 import luckyclient.serverapi.entity.ProjectCaseParams;
 import luckyclient.serverapi.entity.ProjectCaseSteps;
+import org.apache.commons.compress.utils.Lists;
 
 /**
  * =================================================================
@@ -181,7 +182,14 @@ public class ThreadForExecuteCase extends Thread {
                         expectedresults = expectedresults.substring(JSONPATH_SIGN.length());
                         String jsonpath = expectedresults.split("=")[0];
                         String exceptResult = expectedresults.split("=")[1];
-                        List<String> exceptResults = Arrays.asList(exceptResult.split(","));
+
+                        List<String> exceptResultList = Arrays.asList(exceptResult.split("(?<!&),"));
+                        List<String> exceptResults = Lists.newArrayList();
+                        // 处理期望值里本身包含英文逗号的情况
+                        for (String s : exceptResultList) {
+                            s = s.replace("&,",",");
+                            exceptResults.add(s);
+                        }
                         Configuration conf = Configuration.defaultConfiguration();
                         JSONArray datasArray = JSON.parseArray(JSON.toJSONString(JsonPath.using(conf).parse(testnote).read(jsonpath)));
                         List<String> result = JSONObject.parseArray(datasArray.toJSONString(), String.class);

--- a/src/main/java/luckyclient/caserun/exinterface/WebTestCaseDebug.java
+++ b/src/main/java/luckyclient/caserun/exinterface/WebTestCaseDebug.java
@@ -21,6 +21,7 @@ import luckyclient.serverapi.api.PostServerApi;
 import luckyclient.serverapi.entity.ProjectCase;
 import luckyclient.serverapi.entity.ProjectCaseParams;
 import luckyclient.serverapi.entity.ProjectCaseSteps;
+import org.apache.commons.compress.utils.Lists;
 
 /**
  * =================================================================
@@ -151,7 +152,13 @@ public class WebTestCaseDebug {
                         expectedresults = expectedresults.substring(JSONPATH_SIGN.length());
                         String jsonpath = expectedresults.split("=")[0];
                         String exceptResult = expectedresults.split("=")[1];
-                        List<String> exceptResults = Arrays.asList(exceptResult.split(","));
+                        List<String> exceptResultList = Arrays.asList(exceptResult.split("(?<!&),"));
+                        List<String> exceptResults = Lists.newArrayList();
+                        // 处理期望值里本身包含英文逗号的情况
+                        for (String s : exceptResultList) {
+                            s = s.replace("&,",",");
+                            exceptResults.add(s);
+                        }
                         Configuration conf = Configuration.defaultConfiguration();
                         JSONArray datasArray = JSON.parseArray(JSON.toJSONString(JsonPath.using(conf).parse(testnote).read(jsonpath)));
                         List<String> result = JSONObject.parseArray(datasArray.toJSONString(), String.class);


### PR DESCRIPTION
处理jsonpath断言，期望结果本身包含英文逗号的情况，处理策略：本身包含英文逗号，在逗号前加&符号，由于后端处理策略是split()方法，所以采用.split("(?<!&),") (反向否定预查)来处理。